### PR TITLE
Run def-conversions only once

### DIFF
--- a/test/reload_test.clj
+++ b/test/reload_test.clj
@@ -1,0 +1,7 @@
+(ns reload_test
+  (:require [byte-streams]
+            [clojure.test :refer :all]))
+
+(deftest test-reload
+  (dotimes [_ 5]
+    (use 'byte-streams :reload-all)))


### PR DESCRIPTION
Fix #26 

Adding `?w=1` will rule out the whitespace differences and show just the couple of lines that changed. Here's a link: https://github.com/ztellman/byte-streams/pull/27/files?w=1